### PR TITLE
Use wrappers instead of optional for compatibillity with dotnet

### DIFF
--- a/proto/user_service/user.proto
+++ b/proto/user_service/user.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/wrappers.proto";
+
 package user_service;
 option go_package = ".;user_service";
 
@@ -33,11 +35,11 @@ message CreateUserResponse {
 message UpdateUserRequest {
   TokenClaims claims = 1;
   string id = 2;
-  // optional is experimental
-  optional bool isAdmin = 3;
-  optional string username = 4;
-  optional string email = 5;
-  optional string password = 6;
+  // TODO: Replace with optionals later when dotnet is compatible to it.
+  google.protobuf.BoolValue isAdmin = 3;
+  google.protobuf.StringValue username = 4;
+  google.protobuf.StringValue email = 5;
+  google.protobuf.StringValue password = 6;
 }
 
 message UpdateUserResponse {


### PR DESCRIPTION
As the building of the last Nuget package failed:
There seems currently to be no easy way to enable the experimental optionals for proto3 for dotnet.
That's why I replaced them by wrappers which work similar, but have some more overhead in usage.